### PR TITLE
Tg5040 stop wpa_supplicant fix

### DIFF
--- a/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
@@ -89,7 +89,15 @@ rfkill block bluetooth
 rfkill block wifi
 killall udhcpc
 killall MtpDaemon
-/etc/init.d/wpa_supplicant stop # not sure this is working
+# Wait for wpa_supplicant to fully start before attempting to stop it
+for i in $(seq 1 10); do
+    if pgrep -x "wpa_supplicant" > /dev/null; then
+        echo "Stopping wpa_supplicant" > /dev/console
+        /etc/init.d/wpa_supplicant stop
+        break
+    fi
+    sleep 0.25
+done
 
 keymon.elf & # &> $SDCARD_PATH/keymon.txt &
 

--- a/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
@@ -90,7 +90,7 @@ rfkill block wifi
 killall udhcpc
 killall MtpDaemon
 for i in $(seq 1 10); do
-    if ps | grep "{S[0-9]*wpa_supplica}" | grep -v grep > /dev/null; then
+    if pgrep -f "S[0-9]*wpa_supplicant" > /dev/null; then
         sleep 0.25
         continue
     fi

--- a/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
@@ -92,7 +92,6 @@ killall MtpDaemon
 # Wait for wpa_supplicant to fully start before attempting to stop it
 for i in $(seq 1 10); do
     if pgrep -x "wpa_supplicant" > /dev/null; then
-        echo "Stopping wpa_supplicant" > /dev/console
         /etc/init.d/wpa_supplicant stop
         break
     fi

--- a/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
@@ -89,14 +89,14 @@ rfkill block bluetooth
 rfkill block wifi
 killall udhcpc
 killall MtpDaemon
-# Wait for wpa_supplicant to fully start before attempting to stop it
 for i in $(seq 1 10); do
-    if pgrep -x "wpa_supplicant" > /dev/null; then
-        /etc/init.d/wpa_supplicant stop
-        break
+    if ps | grep "{S[0-9]*wpa_supplica}" | grep -v grep > /dev/null; then
+        sleep 0.25
+        continue
     fi
-    sleep 0.25
+    break
 done
+/etc/init.d/wpa_supplicant stop
 
 keymon.elf & # &> $SDCARD_PATH/keymon.txt &
 


### PR DESCRIPTION
Currently in launch.sh for the brick there is a line attempting to stop wpa_supplicant as part of disabling networking.  The note that it may not be working is correct.  When this attempts to stop wpa_supplicant it is still starting, at this time a ps | grep wpa shows:

1829 root 3972 S {S96wpa_supplica} /bin/sh /etc/rc.common /etc/rc.d/S

/etc/init.d/wpa_supplicant stop is ignored during this time.

Looping until it is done starting then stopping it fixes the issue.  I've found that it's taking 1.75 seconds on my device for it to finish starting in this case.  I've capped it at 2.5 seconds in the loop, but it's been consistent in my testing on my device.

I can see that wifi is a feature you'd like to add later, but at least for now this puts it into a known state so it can be brought up in a more intentional manner.  I'm also not sure how you feel about an intentional delay in the startup sequence, but if nothing else this shows what's going on and why it isn't working as intended now.