### PR TITLE
Game Tracker: subfolder media logic

### DIFF
--- a/workspace/all/common/utils.c
+++ b/workspace/all/common/utils.c
@@ -213,6 +213,18 @@ const char *baseName(const char *filename)
     char *p = strrchr(filename, '/');
     return p ? p + 1 : (char *)filename;
 }
+void folderPath(const char *path, char *result) {
+    char pathCopy[256];  
+    strcpy(pathCopy, path);
+
+    char *lastSlash = strrchr(pathCopy, '/');  // Find the last slash
+    if (lastSlash != NULL) {
+        *lastSlash = '\0';  // Cut off the filename
+        strcpy(result, pathCopy);  // Copy the remaining path
+    } else {
+        strcpy(result, "");  // No folder found
+    }
+}
 void cleanName(char *name_out, const char *file_name)
 {
     char *name_without_ext = removeExtension(file_name);

--- a/workspace/all/common/utils.h
+++ b/workspace/all/common/utils.h
@@ -18,6 +18,7 @@ void serializeTime(char *dest_str, int nTime);
 int countChar(const char *str, char ch);
 char *removeExtension(const char *myStr);
 const char *baseName(const char *filename);
+void folderPath(const char *filePath, char *folder_path);
 void cleanName(char *name_out, const char *file_name);
 bool pathRelativeTo(char *path_out, const char *dir_from, const char *file_to);
 

--- a/workspace/all/libgametimedb/gametimedb.c
+++ b/workspace/all/libgametimedb/gametimedb.c
@@ -69,11 +69,18 @@ void get_rom_image_path(char *rom_file, char *out_image_path)
     if (suffixMatch(rom_file, ".p8") || suffixMatch(rom_file, ".png")) {
         snprintf(out_image_path, STR_MAX - 1, ROMS_PATH "/%s", rom_file);
     }
-
+    
     char *clean_rom_name = removeExtension(baseName(rom_file));
-    char *rom_folder = strtok(rom_file, "/");
+    // this assumes all media resides in a top-level .media folder
+    //char *rom_folder = strtok(rom_file, "/");
+    //snprintf(out_image_path, STR_MAX - 1, ROMS_PATH "/%s/.media/%s.png", rom_folder, clean_rom_name);
+    // this assumes that roms in subfolders have corresponding game art in
+    // a .media folder in the respective subfolder
+    char rom_folder_path[MAX_PATH];
+    folderPath(rom_file, rom_folder_path);
 
-    snprintf(out_image_path, STR_MAX - 1, ROMS_PATH "/%s/.media/%s.png", rom_folder, clean_rom_name);
+    snprintf(out_image_path, STR_MAX - 1, ROMS_PATH "/%s/.media/%s.png", rom_folder_path, clean_rom_name);
+    printf("out_image_path: %s\n", out_image_path);
     free(clean_rom_name);
 }
 


### PR DESCRIPTION
Attempts to fix #109 .

Instead of assuming all game media in e.g. `Game Boy (GB)/.media` (even for Roms in subfolders), scan the respective subfolders for their own .media folder instead.

With this change, a given Rom at `Game Boy (GB)/My Collection/Rom.zip` will expect game art at `Game Boy (GB)/My Collection/.media/Rom.png`, which should align with the behavior of game art in the main UI.