### PR TITLE
Allow opt-in usage of srm-suffixed save files

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -386,9 +386,27 @@ static void Game_changeDisc(char* path) {
 
 ///////////////////////////////////////
 
-static void SRAM_getPath(char* filename) {
-	sprintf(filename, "%s/%s.sav", core.saves_dir, game.name);
+static void formatSRMPath(char* work_name, char* filename) {
+	char* tmp = strrchr(work_name, '.');
+	if (tmp != NULL && strlen(tmp) > 2 && strlen(tmp) <= 5) {
+		tmp[0] = '\0';
+	}
+	sprintf(filename, "%s/%s.srm", core.saves_dir, work_name);
 }
+
+static void SRAM_getPath(char* filename) {
+	char work_name[MAX_PATH];
+
+	if (exists(SHARED_USERDATA_PATH "/use_srm_saves")) {
+		strcpy(work_name, game.name);
+		formatSRMPath(work_name, filename);
+	} else {
+		sprintf(filename, "%s/%s.sav", core.saves_dir, game.name);
+	}
+
+	LOG_info("SRAM_getPath %s\n", filename);
+}
+
 static void SRAM_read(void) {
 	size_t sram_size = core.get_memory_size(RETRO_MEMORY_SAVE_RAM);
 	if (!sram_size) return;


### PR DESCRIPTION
Shamelessly rips off @SFrost007 PR https://github.com/shauninman/MinUI/pull/35

> This tweak allows users to opt in to alternate save file naming (foo.srm rather than the default foo.zip.sav) which makes syncing saves to other RetroArch-based handhelds easier.
>
> The option is enabled by creating an empty file called use_srm_saves, similar to how show_24hour is checked. But I thought best to read this from SHARED_USERDATA_PATH so it applies to all platforms, making a given SD card install portable across platforms whether the option is enabled or not.
>
> Default behaviour is left unaffected by this change, it's purely an opt-in change.

I've tested this in MinUI, but not NextUI. I'm having trouble building NextUI locally on my own. I will follow up if/when I get a working build, but would appreciate someone else testing this if your environment is already set up.