### PR TITLE
Change supafaust thread affinity to best suit quad-core CPU 

### DIFF
--- a/skeleton/EXTRAS/Emus/tg5040/SUPA.pak/default.cfg
+++ b/skeleton/EXTRAS/Emus/tg5040/SUPA.pak/default.cfg
@@ -1,5 +1,6 @@
 -supafaust_pixel_format = rgb565
--supafaust_thread_affinity_emu = 0x0
+-supafaust_thread_affinity_emu = 0x3
+-supafaust_thread_affinity_emu = 0xc
 
 bind Up = UP
 bind Down = DOWN

--- a/skeleton/EXTRAS/Emus/tg5040/SUPA.pak/default.cfg
+++ b/skeleton/EXTRAS/Emus/tg5040/SUPA.pak/default.cfg
@@ -1,6 +1,6 @@
 -supafaust_pixel_format = rgb565
 -supafaust_thread_affinity_emu = 0x3
--supafaust_thread_affinity_emu = 0xc
+-supafaust_thread_affinity_ppu = 0xc
 
 bind Up = UP
 bind Down = DOWN


### PR DESCRIPTION
Provides a slight (even more so on lower end quadcore systems i.e. A7) performance boost, most apparent on Mode7 and SuperFX games