### PR TITLE
Remove useless debug messages

### DIFF
--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -32,21 +32,24 @@ void LOG_note(int level, const char* fmt, ...) {
 #ifdef DEBUG
 	case LOG_DEBUG:
 		printf("[DEBUG] %s", buf);
+		fflush(stdout);
 		break;
 #endif
 	case LOG_INFO:
 		printf("[INFO] %s", buf);
+		fflush(stdout);
 		break;
 	case LOG_WARN:
 		fprintf(stderr, "[WARN] %s", buf);
+		fflush(stderr);
 		break;
 	case LOG_ERROR:
 		fprintf(stderr, "[ERROR] %s", buf);
+		fflush(stderr);
 		break;
 	default:
 		break;
 	}
-	fflush(stdout);
 }
 
 ///////////////////////////////

--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -577,14 +577,14 @@ void GFX_flip_fixed_rate(SDL_Surface* screen, double target_fps) {
 		if (offset > max_lost_frames * frame_duration) {
 			frame_index = -1;
 			last_target_fps = 0.0;
-			LOG_warn("%s: lost sync by more than %d frames (late) @%llu -> reset\n\n", __FUNCTION__, max_lost_frames, SDL_GetPerformanceCounter());
+			// LOG_warn("%s: lost sync by more than %d frames (late) @%llu -> reset\n\n", __FUNCTION__, max_lost_frames, SDL_GetPerformanceCounter());
 		}
 	}
 	else {
 		if (offset < -max_lost_frames * frame_duration) {
 			frame_index = -1;
 			last_target_fps = 0.0;
-			LOG_warn("%s: lost sync by more than %d frames (early ?!) @%llu -> reset\n\n", __FUNCTION__, max_lost_frames, SDL_GetPerformanceCounter());
+			// LOG_warn("%s: lost sync by more than %d frames (early ?!) @%llu -> reset\n\n", __FUNCTION__, max_lost_frames, SDL_GetPerformanceCounter());
 		}
 		else if (offset < 0) {
 			useconds_t time_to_sleep_us = (useconds_t) ((time_of_frame - now) * 1e6 / perf_freq);

--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -577,14 +577,14 @@ void GFX_flip_fixed_rate(SDL_Surface* screen, double target_fps) {
 		if (offset > max_lost_frames * frame_duration) {
 			frame_index = -1;
 			last_target_fps = 0.0;
-			// LOG_warn("%s: lost sync by more than %d frames (late) @%llu -> reset\n\n", __FUNCTION__, max_lost_frames, SDL_GetPerformanceCounter());
+			LOG_debug("%s: lost sync by more than %d frames (late) @%llu -> reset\n\n", __FUNCTION__, max_lost_frames, SDL_GetPerformanceCounter());
 		}
 	}
 	else {
 		if (offset < -max_lost_frames * frame_duration) {
 			frame_index = -1;
 			last_target_fps = 0.0;
-			// LOG_warn("%s: lost sync by more than %d frames (early ?!) @%llu -> reset\n\n", __FUNCTION__, max_lost_frames, SDL_GetPerformanceCounter());
+			LOG_debug("%s: lost sync by more than %d frames (early ?!) @%llu -> reset\n\n", __FUNCTION__, max_lost_frames, SDL_GetPerformanceCounter());
 		}
 		else if (offset < 0) {
 			useconds_t time_to_sleep_us = (useconds_t) ((time_of_frame - now) * 1e6 / perf_freq);


### PR DESCRIPTION
This PR removes debug messages that are constantly written when using a demanding emulator (for instance, Amiga emulator). It should prevent wearing up the SD card...