### PR TITLE
Show the "Resume" option when returning to the menu

### DIFF
--- a/workspace/all/minui/minui.c
+++ b/workspace/all/minui/minui.c
@@ -1324,6 +1324,11 @@ static void loadLast(void) { // call after loading root directory
 	}
 	
 	StringArray_free(last);
+
+	if (top->selected >= 0 && top->selected < top->entries->count) {
+		Entry *selected_entry = top->entries->items[top->selected];
+		readyResume(selected_entry);
+	}
 }
 
 ///////////////////////////////////////


### PR DESCRIPTION
This PR fixes a small annoyance: when we quit a game and return to the menu, the "Resume" action of the selected game is not available even if the game has a saved state.
