### PR TITLE
Fix invalid free

### DIFF
--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -564,8 +564,8 @@ void GFX_flip_fixed_rate(SDL_Surface* screen, double target_fps) {
 			useconds_t time_to_sleep_us = (useconds_t) ((time_of_frame - now) * 1e6 / perf_freq);
 
 			// The OS scheduling algorithm cannot guarantee that
-			// the sleep while last the exact amount of requested time.
-			// We sleep as much as we can using the OS primitive
+			// the sleep will last the exact amount of requested time.
+			// We sleep as much as we can using the OS primitive.
 			const useconds_t min_waiting_time = 2000;
 			if (time_to_sleep_us > min_waiting_time) {
 				usleep(time_to_sleep_us - min_waiting_time);

--- a/workspace/tg5040/platform/platform.c
+++ b/workspace/tg5040/platform/platform.c
@@ -455,7 +455,7 @@ void PLAT_setOverlay(int select, const char* tag) {
     const char* filename = overlay_files[select];
 
     if (!filename || strcmp(filename, "") == 0) {
-		overlay_path = "";
+		overlay_path = strdup("");
         printf("Skipping overlay update.\n");
         return;
     }


### PR DESCRIPTION
This PR fixes a crash when exiting a game.
The logs contained the message:
```txt
free(): invalid pointer
Aborted
```

This was due to `free` called on `tg5040/platform/platform.c:216` on a pointer which was a static string.
