### PR TITLE
Improved rom loading and implemented shader caching

### DIFF
--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -280,6 +280,7 @@ int GFX_wrapText(TTF_Font* font, char* str, int max_width, int max_lines);
 #define GFX_resetShaders PLAT_resetShaders	// void:(GFX_Renderer* renderer)
 #define GFX_clearShaders PLAT_clearShaders	// void:(GFX_Renderer* renderer)
 #define GFX_updateShader PLAT_updateShader	// void:(GFX_Renderer* renderer)
+#define GFX_reloadShaders PLAT_reloadShaders	// void:(GFX_Renderer* renderer)
 
 scaler_t GFX_getAAScaler(GFX_Renderer* renderer);
 void GFX_freeAAScaler(void);
@@ -580,6 +581,7 @@ void PLAT_setShader1(const char* filename);
 void PLAT_setShader2(const char* filename);
 void PLAT_setShader3(const char* filename);
 void PLAT_updateShader(int i, const char *filename, int *scale, int *filter, int *scaletype, int *inputtype);
+void PLAT_reloadShaders();
 int PLAT_supportsOverscan(void);
 
 SDL_Surface* PLAT_initOverlay(void);

--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -455,6 +455,7 @@ enum {
 
 FILE *PLAT_OpenSettings(const char *filename);
 FILE *PLAT_WriteSettings(const char *filename);
+char* PLAT_findFileInDir(const char *directory, const char *filename);
 void PLAT_initInput(void);
 void PLAT_quitInput(void);
 void PLAT_pollInput(void);

--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -280,7 +280,7 @@ int GFX_wrapText(TTF_Font* font, char* str, int max_width, int max_lines);
 #define GFX_resetShaders PLAT_resetShaders	// void:(GFX_Renderer* renderer)
 #define GFX_clearShaders PLAT_clearShaders	// void:(GFX_Renderer* renderer)
 #define GFX_updateShader PLAT_updateShader	// void:(GFX_Renderer* renderer)
-#define GFX_reloadShaders PLAT_reloadShaders	// void:(GFX_Renderer* renderer)
+#define GFX_initShaders PLAT_initShaders	// void:(GFX_Renderer* renderer)
 
 scaler_t GFX_getAAScaler(GFX_Renderer* renderer);
 void GFX_freeAAScaler(void);
@@ -581,7 +581,7 @@ void PLAT_setShader1(const char* filename);
 void PLAT_setShader2(const char* filename);
 void PLAT_setShader3(const char* filename);
 void PLAT_updateShader(int i, const char *filename, int *scale, int *filter, int *scaletype, int *inputtype);
-void PLAT_reloadShaders();
+void PLAT_initShaders();
 int PLAT_supportsOverscan(void);
 
 SDL_Surface* PLAT_initOverlay(void);

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -6365,7 +6365,13 @@ int main(int argc , char* argv[]) {
 	
 	LOG_info("rom_path: %s\n", rom_path);
 	
+
+	
 	screen = GFX_init(MODE_MENU);
+
+	// initialize default shaders
+	GFX_initShaders();
+
 	PAD_init();
 	DEVICE_WIDTH = screen->w;
 	DEVICE_HEIGHT = screen->h;
@@ -6432,7 +6438,11 @@ int main(int argc , char* argv[]) {
 	
 	int has_pending_opt_change = 0;
 	LOG_info("Starting shaders %ims\n\n",SDL_GetTicks());
+
+
+	// then initialize custom  shaders from settings
 	initShaders();
+
 	LOG_info("total startup time %ims\n\n",SDL_GetTicks());
 	while (!quit) {
 		GFX_startFrame();

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -134,13 +134,27 @@ static struct Game {
 } game;
 static void Game_open(char* path) {
 	LOG_info("Game_open\n");
+	int skipzip = 0;
 	memset(&game, 0, sizeof(game));
 	
 	strcpy((char*)game.path, path);
 	strcpy((char*)game.name, strrchr(path, '/')+1);
-	
+
+	// check first if the rom already is alive in tmp folder if so skip unzipping shit
+	char tmpfldr[255];
+	snprintf(tmpfldr, sizeof(tmpfldr), "/tmp/nextarch/%s", core.tag);
+	char *tmppath = PLAT_findFileInDir(tmpfldr, game.name);
+	if (tmppath) {
+		printf("File exists skipping unzipping and setting game.tmp_path: %s\n", tmppath);
+		strcpy((char*)game.tmp_path, tmppath);
+		skipzip = 1;
+		free(tmppath);
+	} else {
+		printf("File does not exist in %s\n",tmpfldr);
+	}
+		
 	// if we have a zip file
-	if (suffixMatch(".zip", game.path)) {
+	if (suffixMatch(".zip", game.path) && !skipzip) {
 		LOG_info("is zip file\n");
 		int supports_zip = 0;
 		int i = 0;
@@ -173,7 +187,7 @@ static void Game_open(char* path) {
 	// if the frontend tries to load a 500MB file itself bad things happen
 	if (!core.need_fullpath) {
 		path = game.tmp_path[0]=='\0'?game.path:game.tmp_path;
-		
+
 		FILE *file = fopen(path, "r");
 		if (file==NULL) {
 			LOG_error("Error opening game: %s\n\t%s\n", path, strerror(errno));
@@ -228,7 +242,8 @@ static void Game_open(char* path) {
 }
 static void Game_close(void) {
 	if (game.data) free(game.data);
-	if (game.tmp_path[0]) remove(game.tmp_path);
+	// why delete tempfile? keep it for next time when loading the game its much faster from /tmp ram folder
+	// if (game.tmp_path[0]) remove(game.tmp_path);
 	game.is_open = 0;
 	VIB_setStrength(0); // just in case
 }
@@ -262,9 +277,13 @@ int extract_zip(char** extensions)
 		return 1;
 	}
 
-	char tmp_template[MAX_PATH];
-	strcpy(tmp_template, "/tmp/minarch-XXXXXX");
-	char* tmp_dirname = mkdtemp(tmp_template);
+	// char tmp_template[MAX_PATH];
+	// strcpy(tmp_template, "/tmp/minarch-XXXXXX");
+	
+	mkdir("/tmp/nextarch",0777);
+	char tmp_dirname[255];
+	snprintf(tmp_dirname, sizeof(tmp_dirname), "%s/%s", "/tmp/nextarch",core.tag);
+	mkdir(tmp_dirname,0777);
 
 	int i, len;
 	int fd;
@@ -6371,9 +6390,9 @@ int main(int argc , char* argv[]) {
 	Config_init();
 	Config_readOptions(); // cores with boot logo option (eg. gb) need to load options early
 	setOverclock(overclock);
-	
+
 	Core_init();
-	
+
 	// TODO: find a better place to do this
 	// mixing static and loaded data is messy
 	// why not move to Core_init()?
@@ -6389,10 +6408,10 @@ int main(int argc , char* argv[]) {
 	Menu_init();
 	State_resume();
 	Menu_initState(); // make ready for state shortcuts
-	
+
 	PWR_warn(1);
 	PWR_disableAutosleep();
-	
+
 	// force a vsync immediately before loop
 	// for better frame pacing?
 	GFX_clearAll();
@@ -6402,9 +6421,9 @@ int main(int argc , char* argv[]) {
 	// need to draw real black background first otherwise u get weird pixels sometimes
 
 	GFX_flip(screen);
-	
+
 	Special_init(); // after config
-	
+
 	sec_start = SDL_GetTicks();
 	resetFPSCounter();
 	chooseSyncRef();

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -5113,6 +5113,8 @@ static int OptionCheats_openMenu(MenuList* list, int i) {
 static int OptionShaders_optionChanged(MenuList* list, int i) {
 		MenuItem* item = &list->items[i];
 		Config_syncShaders(item->key, item->value);
+		if(i==SH_NROFSHADERS)
+			initShaders();
 		return MENU_CALLBACK_NOP;
 }
 
@@ -6429,7 +6431,7 @@ int main(int argc , char* argv[]) {
 	chooseSyncRef();
 	
 	int has_pending_opt_change = 0;
-
+	LOG_info("Starting shaders %ims\n\n",SDL_GetTicks());
 	initShaders();
 	LOG_info("total startup time %ims\n\n",SDL_GetTicks());
 	while (!quit) {

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -6431,7 +6431,7 @@ int main(int argc , char* argv[]) {
 	int has_pending_opt_change = 0;
 
 	initShaders();
-
+	LOG_info("total startup time %ims\n\n",SDL_GetTicks());
 	while (!quit) {
 		GFX_startFrame();
 	

--- a/workspace/all/nextui/nextui.c
+++ b/workspace/all/nextui/nextui.c
@@ -1472,7 +1472,7 @@ int main (int argc, char *argv[]) {
 
 	pthread_t cpucheckthread;
     pthread_create(&cpucheckthread, NULL, PLAT_cpu_monitor, NULL);
-	
+	LOG_info("Start time time %ims\n",SDL_GetTicks());
 	while (!quit) {
 
 		GFX_startFrame();

--- a/workspace/tg5040/platform/platform.c
+++ b/workspace/tg5040/platform/platform.c
@@ -338,6 +338,33 @@ GLuint load_shader_from_file(GLenum type, const char* filename, const char* path
     return shader;
 }
 
+void PLAT_initShaders() {
+	SDL_GL_MakeCurrent(vid.window, vid.gl_context);
+	glViewport(0, 0, device_width, device_height);
+	
+	GLuint vertex;
+	GLuint fragment;
+
+	vertex = load_shader_from_file(GL_VERTEX_SHADER, "default.glsl",SYSSHADERS_FOLDER);
+	fragment = load_shader_from_file(GL_FRAGMENT_SHADER, "default.glsl",SYSSHADERS_FOLDER);
+	g_shader_default = link_program(vertex, fragment,"default.glsl");
+
+	vertex = load_shader_from_file(GL_VERTEX_SHADER, "colorfix.glsl", SYSSHADERS_FOLDER);
+	fragment = load_shader_from_file(GL_FRAGMENT_SHADER, "colorfix.glsl",SYSSHADERS_FOLDER);
+	g_shader_color = link_program(vertex, fragment,"colorfix.glsl");
+
+	vertex = load_shader_from_file(GL_VERTEX_SHADER, "overlay.glsl",SYSSHADERS_FOLDER);
+	fragment = load_shader_from_file(GL_FRAGMENT_SHADER, "overlay.glsl",SYSSHADERS_FOLDER);
+	g_shader_overlay = link_program(vertex, fragment,"overlay.glsl");
+	
+	LOG_info("default shaders loaded, %i\n\n",g_shader_default);
+	// for (int i=0; i<nrofshaders; i++) {
+	// 	Shader* shader = shaders[i];
+	// 	LOG_info("shader filename: %s\n",shader->filename);
+	// 	PLAT_updateShader(i, shader->filename,NULL,NULL,NULL,NULL);
+	// }
+}
+
 
 SDL_Surface* PLAT_initVideo(void) {
 	char* device = getenv("DEVICE");
@@ -399,21 +426,6 @@ SDL_Surface* PLAT_initVideo(void) {
 	vid.gl_context = SDL_GL_CreateContext(vid.window);
 	SDL_GL_MakeCurrent(vid.window, vid.gl_context);
 	glViewport(0, 0, w, h);
-	
-	GLuint vertex;
-	GLuint fragment;
-
-	vertex = load_shader_from_file(GL_VERTEX_SHADER, "default.glsl",SYSSHADERS_FOLDER);
-	fragment = load_shader_from_file(GL_FRAGMENT_SHADER, "default.glsl",SYSSHADERS_FOLDER);
-	g_shader_default = link_program(vertex, fragment,"default.glsl");
-
-	vertex = load_shader_from_file(GL_VERTEX_SHADER, "colorfix.glsl",SYSSHADERS_FOLDER);
-	fragment = load_shader_from_file(GL_FRAGMENT_SHADER, "colorfix.glsl",SYSSHADERS_FOLDER);
-	g_shader_color = link_program(vertex, fragment,"colorfix.glsl");
-
-	vertex = load_shader_from_file(GL_VERTEX_SHADER, "overlay.glsl",SYSSHADERS_FOLDER);
-	fragment = load_shader_from_file(GL_FRAGMENT_SHADER, "overlay.glsl",SYSSHADERS_FOLDER);
-	g_shader_overlay = link_program(vertex, fragment,"overlay.glsl");
 
 	vid.stream_layer1 = SDL_CreateTexture(vid.renderer,SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, w,h);
 	vid.target_layer1 = SDL_CreateTexture(vid.renderer,SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET , w,h);
@@ -496,20 +508,11 @@ char* PLAT_findFileInDir(const char *directory, const char *filename) {
     return NULL;
 }
 
-
-void PLAT_reloadShaders() {
-	for (int i=0; i<nrofshaders; i++) {
-		Shader* shader = shaders[i];
-		LOG_info("shader filename: %s\n",shader->filename);
-		PLAT_updateShader(i, shader->filename,NULL,NULL,NULL,NULL);
-	}
-}
 void PLAT_updateShader(int i, const char *filename, int *scale, int *filter, int *scaletype, int *srctype) {
     // Check if the shader index is valid
     if (i < 0 || i >= nrofshaders) {
         return;
     }
-	LOG_info("update shader\n");
     Shader* shader = shaders[i];
 
     // Only update shader_p if filename is not NULL


### PR DESCRIPTION
Faster rom loading:
 Roms are not anymore removed from the /tmp folder, but stay there in a designated folder /tmp/SFC/super mario.sfc
 When game is started again (for example game switcher resume) and rom is already found it will skip the zip extraction process and directly loads the rom, improves game start time for about 1,5 seconds faster.
 
This only applies to cores that don't have zip file support and do not require to read from source roms like pcsx rearmed
/tmp is a RAM store on the brick so provides faster access then loading and extracting from SD card each time

Shader cache:
Implemented a shader cache so shaders don't need to compile from source code each they are loaded. Shader cache resides in .shadercache on the root of your SDCard

 