### PR TITLE
new background file for roms list bglist.png and also screen filter f…

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -1729,12 +1729,6 @@ static void Config_syncFrontend(char* key, int value) {
 		i = FE_OPT_SCREENY;
 	}
 	else if (exactMatch(key,config.frontend.options[FE_OPT_SHARPNESS].key)) {
-		// screen_sharpness = value;
-		
-		// if (screen_scaling==SCALE_NATIVE) GFX_setSharpness(SHARPNESS_SHARP);
-		// else GFX_setSharpness(screen_sharpness);
-
-		// renderer.dst_p = 0;
 		GFX_setSharpness(value);
 		i = FE_OPT_SHARPNESS;
 	}


### PR DESCRIPTION
Added new option now when inside the roms list it will look for bglist.png in the .media folder in the roms section so you can have seperate backgrounds for the system for on the main menu and while in the roms list, otherwise it will go back to default bg.png or black background

Cleaned up background drawing code and fixed everything

Fixed Screen sharpness setting resetting when changing aspect ratio