### PR TITLE
feat: allow disabling savestates

### DIFF
--- a/PAKS.md
+++ b/PAKS.md
@@ -49,6 +49,8 @@ This will open the requested rom using the "picodrive\_libretro.so" core include
 
 There's no need to edit anything below the line of hash marks. The rest is boilerplate that will extract the pak's tag from its folder name, create corresponding bios and save folders, set the `HOME` envar to "/.userdata/[platform]/", launch the game, and log any output from minarch and the core to "/.userdata/[platform]/logs/[TAG].txt".
 
+Some libretro cores do not support savestates. To disable savestates from appearing in the UI, create a `disable_savestates` file in the emulator's pak folder.
+
 That's it! Feel free to experiement with cores from the stock firmware, other compatible devices, or building your own.
 
 Oh, if you're creating a pak for Anbernic's RG*XX line you'll need to change the last part of the last line from ` &> "$LOGS_PATH/$EMU_TAG.txt"` to ` > "$LOGS_PATH/$EMU_TAG.txt" 2>&1` because its default shell is whack.

--- a/PAKS.md
+++ b/PAKS.md
@@ -49,7 +49,11 @@ This will open the requested rom using the "picodrive\_libretro.so" core include
 
 There's no need to edit anything below the line of hash marks. The rest is boilerplate that will extract the pak's tag from its folder name, create corresponding bios and save folders, set the `HOME` envar to "/.userdata/[platform]/", launch the game, and log any output from minarch and the core to "/.userdata/[platform]/logs/[TAG].txt".
 
-Some libretro cores do not support savestates. To disable savestates from appearing in the UI, create a `disable_savestates` file in the emulator's pak folder.
+Some libretro cores do not support savestates. To disable savestates from appearing in the UI, set the `minarch_savestates` property to `off` in the `default.cfg` file in the emulator's pak folder.
+
+```
+minarch_savestates = off
+```
 
 That's it! Feel free to experiement with cores from the stock firmware, other compatible devices, or building your own.
 


### PR DESCRIPTION
Some libretro cores do not support savestates, and including them in the UI causes users to falsely believe they will work as the screenshot is taken but the file is not written. Rather than just disable the screenshot functionality, remove the options altogether to avoid confusion.

To remove the load/save options from the minarch menu, create a disable_savestates file in the emulator's pak folder.