### PR TITLE
fix: adjust error handling in suspend script

### DIFF
--- a/skeleton/SYSTEM/tg5040/bin/suspend
+++ b/skeleton/SYSTEM/tg5040/bin/suspend
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -euo pipefail
+set -eu
 exec 0<&-
 
 wpa_running=
@@ -51,7 +51,7 @@ after() {
 	if [ -n "$wpa_running" ]; then
 		>&2 echo "Starting wpa_supplicant..."
 		wpa_supplicant -B -iwlan0 -Dnl80211 -c/etc/wifi/wpa_supplicant.conf -I/etc/wifi/wpa_supplicant_overlay.conf -O/etc/wifi/sockets || true
-		(( udhcpc -i wlan0 &)&)
+		udhcpc -i wlan0 &
 	fi
 
 	if [ -n "$hciattach_running" ]; then
@@ -68,7 +68,7 @@ after() {
 before
 
 >&2 echo "Suspending..."
-echo mem >/sys/power/state
+echo mem >/sys/power/state || true
 
 # Resume services in background to reduce UI latency
-(( after &)&)
+after &


### PR DESCRIPTION
This PR updates the suspend script with these changes:

- Removed `-o pipefail` from the set command as it's not supported in sh.
- Fixed backgrounding of udhcpc and after functions by replacing unnecessary double parentheses with standard backgrounding (&).
- Made writing to `/sys/power/state` non-fatal by appending || true, preventing the script from exiting if the suspend command fails.

I've made these changes because when developing [minui-power-control ](https://github.com/ben16w/minui-power-control) sometimes the WiFi doesn't restore after resuming from suspend. Looking at the logs, I found:

```
Preparing for suspend...
Saving mixer state...
Blocking wireless...
Suspending...
sh: write error: Device or resource busy
```

The suspend script is failing at `echo mem >/sys/power/state` (even though the device does still suspend). This causes the script to fail and exit. The `after` function then doesn't run and WiFi/Bluetooth are not restored. This PR fixes that so that the `after` function always runs regardless of erorrs with `echo mem >/sys/power/state`.
