### PR TITLE
No-sound on in game sleep / resume fix attempt

### DIFF
--- a/skeleton/SYSTEM/tg5040/bin/suspend
+++ b/skeleton/SYSTEM/tg5040/bin/suspend
@@ -11,9 +11,9 @@ asound_state_dir=/tmp/asound-suspend
 before() {
 	>&2 echo "Preparing for suspend..."
 
-	>&2 echo "Saving mixer state..."
+	>&2 echo "Saving mixer state... The cake is a lie"
 	mkdir -p "$asound_state_dir"
-	alsactl --file "$asound_state_dir/asound.state.pre" store || true
+	# alsactl --file "/tmp/asound-suspend/asound.state.pre" store || true
 
 	if pgrep wpa_supplicant; then
 		wpa_running=1
@@ -41,9 +41,9 @@ before() {
 after() {
 	>&2 echo "Resumed from suspend."
 
-	>&2 echo "Restoring mixer state..."
-	alsactl --file "$asound_state_dir/asound.state.post" store || true
-	alsactl --file "$asound_state_dir/asound.state.pre" restore || true
+	>&2 echo "Restoring mixer state... Jumping through portals"
+	# alsactl --file "$asound_state_dir/asound.state.post" store || true
+	# alsactl --file "$asound_state_dir/asound.state.pre" restore || true
 
 	>&2 echo "Unblocking wireless..."
 	echo 1 >/sys/class/rfkill/rfkill0/state || true
@@ -71,4 +71,10 @@ before
 echo mem >/sys/power/state
 
 # Resume services in background to reduce UI latency
-(( after &)&)
+
+# The no-sound bug might actually be happening here
+# While testing my initial solution (disabling alsactl store/restore) I still expirienced the no-sound bug, but yeah still don't see why they run as there's no difference with our without?
+# But thinking about this, running the after function in the background theoretically actually could cause problems as it allows nextarch to run while all this resuming stuff is still happening, maybe it causes a condition where nextarch is already running before the sound driver is even ready?
+# Testing with unbackgrounded after() I didnt expirience the no sound bug yet (but needs more testing preferrably my more users). I also see 0 difference in resume times tbh, maybe this was code what helped resume time on other devices so they left it like this.
+# (( after &)&)
+after

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -2494,12 +2494,11 @@ void loadShaderSettings() {
 	for (int i=0; i < config.shaders.options[SH_NROFSHADERS].value; i++) {
 		ShaderParam *params = PLAT_getShaderPragmas(i);
 		for (int j = 0; j < 32; j++) {
-			if(params[j].def) {
+			if(params[j].def || params[j].min || params[j].max) {
 				config.shaderpragmas.options[menucount].key = params[j].name;
 				config.shaderpragmas.options[menucount].name = params[j].name;
 				config.shaderpragmas.options[menucount].desc = params[j].name;
 				config.shaderpragmas.options[menucount].default_value = params[j].def;
-				config.shaderpragmas.options[menucount].value = params[j].value;
 				
 				int steps = (int)((params[j].max - params[j].min) / params[j].step) + 1;
 				config.shaderpragmas.options[menucount].values = malloc(sizeof(char *) * (steps + 1));
@@ -2510,6 +2509,8 @@ void loadShaderSettings() {
 					snprintf(str, 16, "%.2f", val);
 					config.shaderpragmas.options[menucount].values[s] = str;
 					config.shaderpragmas.options[menucount].labels[s] = str;
+					if(params[j].value == val)
+						config.shaderpragmas.options[menucount].value = s;
 				}
 				config.shaderpragmas.options[menucount].count = steps;
 				config.shaderpragmas.options[menucount].values[steps] = NULL;

--- a/workspace/macos/platform/platform.c
+++ b/workspace/macos/platform/platform.c
@@ -873,8 +873,8 @@ void PLAT_updateShader(int i, const char *filename, int *scale, int *filter, int
         snprintf(filepath, sizeof(filepath), SHADERS_FOLDER "/glsl/%s",filename);
         const char *shaderSource  = load_shader_source(filepath);
         loadShaderPragmas(shader,shaderSource);
-        GLuint vertex_shader1 = load_shader_from_file(GL_VERTEX_SHADER, filename,SHADERS_FOLDER "/glsl");
-
+         GLuint vertex_shader1 = load_shader_from_file(GL_VERTEX_SHADER, filename,SHADERS_FOLDER "/glsl");
+    GLuint fragment_shader1 = load_shader_from_file(GL_FRAGMENT_SHADER, filename,SHADERS_FOLDER "/glsl");
         
         
         // Link the shader program

--- a/workspace/macos/platform/platform.c
+++ b/workspace/macos/platform/platform.c
@@ -894,7 +894,7 @@ void PLAT_updateShader(int i, const char *filename, int *scale, int *filter, int
 		shader->texelSizeLocation = glGetUniformLocation(shader->shader_p, "texelSize");
 		for (int i = 0; i < shader->num_pragmas; ++i) {
 			shader->pragmas[i].uniformLocation = glGetUniformLocation(shader->shader_p, shader->pragmas[i].name);
-			shader->pragmas[i].value = shader->pragmas[i].min;
+			shader->pragmas[i].value = shader->pragmas[i].def;
 			printf("Param: %s = %f (min: %f, max: %f, step: %f)\n",
 				shader->pragmas[i].name,
 				shader->pragmas[i].def,

--- a/workspace/macos/platform/platform.c
+++ b/workspace/macos/platform/platform.c
@@ -894,7 +894,7 @@ void PLAT_updateShader(int i, const char *filename, int *scale, int *filter, int
 		shader->texelSizeLocation = glGetUniformLocation(shader->shader_p, "texelSize");
 		for (int i = 0; i < shader->num_pragmas; ++i) {
 			shader->pragmas[i].uniformLocation = glGetUniformLocation(shader->shader_p, shader->pragmas[i].name);
-			shader->pragmas[i].value = shader->pragmas[i].def;
+			shader->pragmas[i].value = shader->pragmas[i].min;
 			printf("Param: %s = %f (min: %f, max: %f, step: %f)\n",
 				shader->pragmas[i].name,
 				shader->pragmas[i].def,

--- a/workspace/tg5040/platform/platform.c
+++ b/workspace/tg5040/platform/platform.c
@@ -605,7 +605,8 @@ void PLAT_updateShader(int i, const char *filename, int *scale, int *filter, int
 		shader->texelSizeLocation = glGetUniformLocation(shader->shader_p, "texelSize");
 		for (int i = 0; i < shader->num_pragmas; ++i) {
 			shader->pragmas[i].uniformLocation = glGetUniformLocation(shader->shader_p, shader->pragmas[i].name);
-			shader->pragmas[i].value = shader->pragmas[i].min;
+			shader->pragmas[i].value = shader->pragmas[i].def;
+
 			printf("Param: %s = %f (min: %f, max: %f, step: %f)\n",
 				shader->pragmas[i].name,
 				shader->pragmas[i].def,

--- a/workspace/tg5040/platform/platform.c
+++ b/workspace/tg5040/platform/platform.c
@@ -605,7 +605,7 @@ void PLAT_updateShader(int i, const char *filename, int *scale, int *filter, int
 		shader->texelSizeLocation = glGetUniformLocation(shader->shader_p, "texelSize");
 		for (int i = 0; i < shader->num_pragmas; ++i) {
 			shader->pragmas[i].uniformLocation = glGetUniformLocation(shader->shader_p, shader->pragmas[i].name);
-			shader->pragmas[i].value = shader->pragmas[i].min;
+			shader->pragmas[i].value = shader->pragmas[i].def;
 			printf("Param: %s = %f (min: %f, max: %f, step: %f)\n",
 				shader->pragmas[i].name,
 				shader->pragmas[i].def,

--- a/workspace/tg5040/platform/platform.c
+++ b/workspace/tg5040/platform/platform.c
@@ -585,9 +585,9 @@ void PLAT_updateShader(int i, const char *filename, int *scale, int *filter, int
 		const char *shaderSource  = load_shader_source(filepath);
 		loadShaderPragmas(shader,shaderSource);
 
-    GLuint vertex_shader1 = load_shader_from_file(GL_VERTEX_SHADER, filename,SHADERS_FOLDER "/glsl");
-    GLuint fragment_shader1 = load_shader_from_file(GL_FRAGMENT_SHADER, filename,SHADERS_FOLDER "/glsl");
-        
+		GLuint vertex_shader1 = load_shader_from_file(GL_VERTEX_SHADER, filename,SHADERS_FOLDER "/glsl");
+		GLuint fragment_shader1 = load_shader_from_file(GL_FRAGMENT_SHADER, filename,SHADERS_FOLDER "/glsl");
+			
         // Link the shader program
 		if (shader->shader_p != 0) {
 			LOG_info("Deleting previous shader %i\n",shader->shader_p);
@@ -605,7 +605,7 @@ void PLAT_updateShader(int i, const char *filename, int *scale, int *filter, int
 		shader->texelSizeLocation = glGetUniformLocation(shader->shader_p, "texelSize");
 		for (int i = 0; i < shader->num_pragmas; ++i) {
 			shader->pragmas[i].uniformLocation = glGetUniformLocation(shader->shader_p, shader->pragmas[i].name);
-			shader->pragmas[i].value = shader->pragmas[i].def;
+			shader->pragmas[i].value = shader->pragmas[i].min;
 			printf("Param: %s = %f (min: %f, max: %f, step: %f)\n",
 				shader->pragmas[i].name,
 				shader->pragmas[i].def,


### PR DESCRIPTION
Expiriencing this bug myself finally I got to take a look at the logs when this happens. The only real hint I could find searching through all the logs was the following line

ERROR: ALSA write failed (unrecoverable): File descriptor in bad state 

Which seemed to be happening somewhere in the suspend script. Looking over this script I noticed 2 things first the alsa store/restore commands

alsactl --file "$asound_state_dir/asound.state.post" store || true

I get why they are here, but I wonder if they are really needed. It looks like the internal firmware is already handling this properly so I'm not sure if we really need to do this. Disabling these commands made no difference and sleeping resuming has no noticable changes with our without these commands. Sound still restores at the same volume so yeah. 

However disabling these commands unfortunately did not resolve the bug as after a couple of sleep resume tries I still got the bug, so I looked into it a bit further and than I realize the resume part of the script was running backgrounded. The reason why is commented as 

`Resume services in background to reduce UI latency`

But this means when you resume directly back into the game it will run nextarch while the resume stuff is still running which my suspicion is that it could be the game will start running even before the sound driver is ready to accept sound. 

I've run now a couple of tests sleeping/resuming with running after() normally without backgrounding. Firstly I really see no difference at all in resume speed, but second I did not expirience the no-sound bug yet. So I think this might resolve the issue. But yeah it def needs more testing as this is a very random bug happening very inconsistently as its probably something being timing dependent. But for now I got high hopes on that this solves the issue. But lets do some more testing maybe involving some users before we merge this. 
