### PR TITLE
fix: Improved retry logic in deep sleep script

### DIFF
--- a/skeleton/SYSTEM/tg5040/bin/suspend
+++ b/skeleton/SYSTEM/tg5040/bin/suspend
@@ -22,11 +22,66 @@ before() {
     # This def helps a lot keeping /sys/power/state unlocked a lot more. It doesn't mean it will never be locked as other things can lock it too. But hopefully the retry mechanism inside platform.c is enough to now always properly suspend
     # and disabling audio and wifi/bluetooth hardware is not needed anymore and we can have reliable wifi+audio on resume again. 
 
+    max_retries=10
+    retry_interval=1
+
     for f in $(find /sys/devices/platform/soc/7081400.s_twi/i2c-6/6-0034/ -name wakeup); do
-        echo "Disabling wakeup in $f"
-        echo disabled > "$f"
+            echo "Disabling wakeup in $f"
+            echo disabled > "$f"
     done
-    sleep 2
+
+
+    check_wakeup_sources() {
+        awk '$1=="axp2202-usb" || $1=="axp2202-battery" { sum += $2 } END { if (sum == "") sum = 0; print sum }' /sys/kernel/debug/wakeup_sources
+    }
+
+    echo "Checking wakeup sources..."
+
+    i=1
+    while [ "$i" -le "$max_retries" ]; do
+        count=$(check_wakeup_sources)
+
+        # Ensure count is a number
+        if echo "$count" | grep -qE '^[0-9]+$'; then
+            if [ "$count" -eq 0 ]; then
+            echo "All axp2202 wakeup sources inactive (active_count = 0). Safe to continue."
+            break
+            else
+            echo "Attempt $i/$max_retries: active_count = $count, retrying in $retry_interval second(s)..."
+            fi
+        else
+            echo "Attempt $i/$max_retries: Failed to read active_count (got '$count'), retrying..."
+        fi
+
+        sleep "$retry_interval"
+        i=$((i + 1))
+    done
+    if [ "$i" -gt "$max_retries" ]; then
+        echo "Timed out: wakeup sources still active or unreadable after $max_retries attempts."
+        exit 1
+    fi
+    i=1
+    success=0
+
+    while [ "$i" -le "$max_retries" ]; do
+    if [ -w /sys/power/state ] && grep -qw mem /sys/power/state; then
+        echo "Check $i: OK ... 'mem' supported and writable."
+        success=1
+        break
+    else
+        echo "Check $i: 'mem' not supported or /sys/power/state not writable."
+    fi
+
+    sleep "$retry_interval"
+    i=$((i + 1))
+    done
+
+    if [ "$success" -eq 1 ]; then
+        echo "Test passed: echo mem > /sys/power/state would succeed."
+    else
+        echo "Test failed: unable to echo to /sys/power/state after $max_retries tries."
+        exit 1
+    fi
 
     # Old suspend script stuff which seemed to help in suspending correctly, but aren't the real solution for the problem and cause other problems like wifi and audio sometimes not resuming correctly.
     # Real problem is explained at the top of this script which I'm trying to attempt to solve
@@ -66,7 +121,8 @@ after() {
         echo enabled > "$f"
     done
 
-    # /mnt/SDCARD/Emus/tg5040/PORTS.pak/bin/i2cset -yfr 6 0x34 0x25 0x20
+    # Same old suspend script stuff
+    
 	# >&2 echo "Restoring mixer state..."
 	# alsactl --file "$asound_state_dir/asound.state.post" store || true
 	# alsactl --file "$asound_state_dir/asound.state.pre" restore || true

--- a/skeleton/SYSTEM/tg5040/bin/suspend
+++ b/skeleton/SYSTEM/tg5040/bin/suspend
@@ -26,6 +26,7 @@ before() {
         echo "Disabling wakeup in $f"
         echo disabled > "$f"
     done
+    sleep 2
 
     # Old suspend script stuff which seemed to help in suspending correctly, but aren't the real solution for the problem and cause other problems like wifi and audio sometimes not resuming correctly.
     # Real problem is explained at the top of this script which I'm trying to attempt to solve

--- a/skeleton/SYSTEM/tg5040/bin/suspend
+++ b/skeleton/SYSTEM/tg5040/bin/suspend
@@ -22,7 +22,7 @@ before() {
     # This def helps a lot keeping /sys/power/state unlocked a lot more. It doesn't mean it will never be locked as other things can lock it too. But hopefully the retry mechanism inside platform.c is enough to now always properly suspend
     # and disabling audio and wifi/bluetooth hardware is not needed anymore and we can have reliable wifi+audio on resume again. 
 
-    max_retries=10
+    max_retries=5
     retry_interval=1
 
     for f in $(find /sys/devices/platform/soc/7081400.s_twi/i2c-6/6-0034/ -name wakeup); do
@@ -60,28 +60,26 @@ before() {
         echo "Timed out: wakeup sources still active or unreadable after $max_retries attempts."
         exit 1
     fi
+    
     i=1
-    success=0
-
     while [ "$i" -le "$max_retries" ]; do
-    if [ -w /sys/power/state ] && grep -qw mem /sys/power/state; then
-        echo "Check $i: OK ... 'mem' supported and writable."
-        success=1
-        break
-    else
-        echo "Check $i: 'mem' not supported or /sys/power/state not writable."
-    fi
+        if [ -w /sys/power/state ] && grep -qw mem /sys/power/state; then
+            echo "Attempt $i: Suspending..."
+            if echo mem > /sys/power/state 2>/dev/null; then
+                echo "Suspend success"
+                break
+            else
+                echo "Attempt $i: Suspend failed (device busy or other error), retrying in $retry_interval second(s)..."
+            fi
+        else
+            echo "Check $i: 'mem' not supported or /sys/power/state not writable."
+            exit 1
+        fi
 
-    sleep "$retry_interval"
-    i=$((i + 1))
+        sleep "$retry_interval"
+        i=$((i + 1))
     done
 
-    if [ "$success" -eq 1 ]; then
-        echo "Test passed: echo mem > /sys/power/state would succeed."
-    else
-        echo "Test failed: unable to echo to /sys/power/state after $max_retries tries."
-        exit 1
-    fi
 
     # Old suspend script stuff which seemed to help in suspending correctly, but aren't the real solution for the problem and cause other problems like wifi and audio sometimes not resuming correctly.
     # Real problem is explained at the top of this script which I'm trying to attempt to solve
@@ -122,7 +120,7 @@ after() {
     done
 
     # Same old suspend script stuff
-    
+
 	# >&2 echo "Restoring mixer state..."
 	# alsactl --file "$asound_state_dir/asound.state.post" store || true
 	# alsactl --file "$asound_state_dir/asound.state.pre" restore || true
@@ -149,10 +147,6 @@ after() {
 }
 
 before
-
->&2 echo "Suspending..."
-sync
-echo mem >/sys/power/state
 
 # Resume services in background to reduce UI latency
 after

--- a/skeleton/SYSTEM/tg5040/bin/suspend
+++ b/skeleton/SYSTEM/tg5040/bin/suspend
@@ -10,11 +10,25 @@ asound_state_dir=/tmp/asound-suspend
 
 before() {
 	>&2 echo "Preparing for suspend..."
-    # /mnt/SDCARD/Emus/tg5040/PORTS.pak/bin/i2cset -yfr 6 0x34 0x25 0x21
+
+    # The problem with the brick not being able to suspend seems to be something that has been tried to solved a few times before evidence by multiple code in the original MinUI firmware trying to tackle this problem in multiple ways
+    # The problem is that sometimes it doesnt let you write to echo mem >/sys/power/state because its locked by something. 
+    # The first solution tried to this is just implement a retry mechanism in platform.c that will try up to 3 times and if still failing do a complete shutdown
+    # The second solution tried to this is to disable all hardware like wifi, audio etc before suspending trying to increase changes the state file is unlocked
+    # A combination of both solutions seems to be enough to be able to suspend succesfully within the 3 retries. But disabling and enabling hardware causes other problems like wifi and audio not working correctly when resuming.
+    # The real problem why state file is locked a lot of times is actually caused by that axp2202-battery seems to generate a lot of wakeup calls and it doesn't clear them the active wakeup count always keeps increasing. Causing the state file to be locked a lot increasing the chance for writing to state mem to fail by a lot
+
+    # Below is my solution to this. I am actually able to make the axp2202 stop generating wakeup locks by sending disabled to each wakeup endpoint in the below sysf folder.
+    # This def helps a lot keeping /sys/power/state unlocked a lot more. It doesn't mean it will never be locked as other things can lock it too. But hopefully the retry mechanism inside platform.c is enough to now always properly suspend
+    # and disabling audio and wifi/bluetooth hardware is not needed anymore and we can have reliable wifi+audio on resume again. 
+
     for f in $(find /sys/devices/platform/soc/7081400.s_twi/i2c-6/6-0034/ -name wakeup); do
         echo "Disabling wakeup in $f"
         echo disabled > "$f"
     done
+
+    # Old suspend script stuff which seemed to help in suspending correctly, but aren't the real solution for the problem and cause other problems like wifi and audio sometimes not resuming correctly.
+    # Real problem is explained at the top of this script which I'm trying to attempt to solve
 
 	# >&2 echo "Saving mixer state..."
 	# mkdir -p "$asound_state_dir"
@@ -47,9 +61,10 @@ after() {
 	>&2 echo "Resumed from suspend."
 
     for f in $(find /sys/devices/platform/soc/7081400.s_twi/i2c-6/6-0034/ -name wakeup); do
-        echo "Disabling wakeup in $f"
+        echo "Enabling wakeup in $f"
         echo enabled > "$f"
     done
+
     # /mnt/SDCARD/Emus/tg5040/PORTS.pak/bin/i2cset -yfr 6 0x34 0x25 0x20
 	# >&2 echo "Restoring mixer state..."
 	# alsactl --file "$asound_state_dir/asound.state.post" store || true

--- a/skeleton/SYSTEM/tg5040/bin/suspend
+++ b/skeleton/SYSTEM/tg5040/bin/suspend
@@ -60,7 +60,6 @@ before() {
         echo "Timed out: wakeup sources still active or unreadable after $max_retries attempts."
         exit 1
     fi
-    
     i=1
     while [ "$i" -le "$max_retries" ]; do
         if [ -w /sys/power/state ] && grep -qw mem /sys/power/state; then


### PR DESCRIPTION
Added more advanced retry logic in the suspend script itself to not only rely on the platform.c logic 