### PR TITLE
Update README.md with corrected Installation Guide URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <hr>
 
 <h4 align="center">
-  <a href="https://nextui.loveretro.games/getting-started/" target="_blank">Installation Guide</a>
+  <a href="https://nextui.loveretro.games/usage/#getting-started" target="_blank">Installation Guide</a>
   ·
   <a href="https://nextui.loveretro.games/docs/" target="_blank">Documentation</a>
   ·


### PR DESCRIPTION
It seems like the readme is using an outdated link to the getting started/installation guide.

Maybe the obsolete page should also be removed or redirected to the proper link?