### PR TITLE
fix: Actual Retroarch naming scheme for srm without breaking current installs

### DIFF
--- a/workspace/all/common/config.h
+++ b/workspace/all/common/config.h
@@ -21,16 +21,27 @@ typedef int (*ColorSet_callback_t)(void);
 
 enum
 {
+	// MinUI: Game.gba.sav
 	SAVE_FORMAT_SAV,
+	//Retroarch: Game.srm
 	SAVE_FORMAT_SRM,
+	// Generic: Game.sav
 	SAVE_FORMAT_GEN,
+	//Retroarch: Game.srm
 	SAVE_FORMAT_SRM_UNCOMPRESSED
 };
 
 enum
 {
+	// MinUI: Game.st0
 	STATE_FORMAT_SAV,
+	//Retroarch-ish: Game.state.<n> (a typo, but keeping it to avoid a breaking change)
+	STATE_FORMAT_SRM_EXTRADOT,
+	//Retroarch-ish: Game.state.<n> (a typo, but keeping it to avoid a breaking change)
+	STATE_FORMAT_SRM_UNCOMRESSED_EXTRADOT,
+	//Retroarch: Game.state<n>
 	STATE_FORMAT_SRM,
+	//Retroarch: Game.state<n>
 	STATE_FORMAT_SRM_UNCOMRESSED
 };
 
@@ -200,7 +211,7 @@ int CFG_getSaveFormat(void);
 void CFG_setSaveFormat(int);
 // Save state format to use for libretro cores
 // 0 - .st0
-// 1 - .state.0 (compressed rzip)
+// 1 - .state.<n> (compressed rzip)
 int CFG_getStateFormat(void);
 void CFG_setStateFormat(int);
 // Enable/disable mute also shutting off LEDs.

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -820,7 +820,7 @@ static void State_read(void) { // from picoarch
 
 	// TODO: rzipstream_open can also handle uncompressed, else branch is probably unnecessary
 	// srm, potentially compressed
-	if (CFG_getStateFormat() == STATE_FORMAT_SRM || (CFG_getStateFormat() == STATE_FORMAT_SRM_EXTRADOT) {
+	if (CFG_getStateFormat() == STATE_FORMAT_SRM || CFG_getStateFormat() == STATE_FORMAT_SRM_EXTRADOT) {
 		state_rzfile = rzipstream_open(filename, RETRO_VFS_FILE_ACCESS_READ);
 		if(!state_rzfile) {
 			if (state_slot!=8) { // st8 is a default state in MiniUI and may not exist, that's okay
@@ -916,7 +916,7 @@ static void State_write(void) { // from picoarch
 	char filename[MAX_PATH];
 	State_getPath(filename);
 #ifdef HAS_SRM
-	if (CFG_getStateFormat() == STATE_FORMAT_SRM || (CFG_getStateFormat() == STATE_FORMAT_SRM_EXTRADOT) {
+	if (CFG_getStateFormat() == STATE_FORMAT_SRM || CFG_getStateFormat() == STATE_FORMAT_SRM_EXTRADOT) {
 		if(!rzipstream_write_file(filename, state, state_size)) {
 			LOG_error("rzipstream: Error writing state data to file: %s\n", filename);
 			goto error;

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -763,6 +763,8 @@ static void formatStatePath(char* work_name, char* filename, const char* suffix)
 static void State_getPath(char* filename) {
 	char work_name[MAX_PATH];
 
+	// This is only here for compatibility with older versions of minarch,
+	// should probably be removed at some point in the future.
 	if (CFG_getStateFormat() == STATE_FORMAT_SRM_EXTRADOT 
 	 || CFG_getStateFormat() == STATE_FORMAT_SRM_UNCOMRESSED_EXTRADOT) {
 		strcpy(work_name, game.name);
@@ -786,6 +788,8 @@ static void State_getPath(char* filename) {
 
 		if(state_slot == AUTO_RESUME_SLOT)
 			sprintf(filename, "%s/%s.state.auto", core.states_dir, work_name);
+		else if(state_slot == 0)
+			sprintf(filename, "%s/%s.state", core.states_dir, work_name);
 		else 
 			sprintf(filename, "%s/%s.state%i", core.states_dir, work_name, state_slot);
 	}

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -763,8 +763,8 @@ static void formatStatePath(char* work_name, char* filename, const char* suffix)
 static void State_getPath(char* filename) {
 	char work_name[MAX_PATH];
 
-	if (CFG_getStateFormat() == STATE_FORMAT_SRM 
-	 || CFG_getStateFormat() == STATE_FORMAT_SRM_UNCOMRESSED) {
+	if (CFG_getStateFormat() == STATE_FORMAT_SRM_EXTRADOT 
+	 || CFG_getStateFormat() == STATE_FORMAT_SRM_UNCOMRESSED_EXTRADOT) {
 		strcpy(work_name, game.name);
 		char* tmp = strrchr(work_name, '.');
 		if (tmp != NULL && strlen(tmp) > 2 && strlen(tmp) <= 5) {
@@ -775,6 +775,19 @@ static void State_getPath(char* filename) {
 			sprintf(filename, "%s/%s.state.auto", core.states_dir, work_name);
 		else 
 			sprintf(filename, "%s/%s.state.%i", core.states_dir, work_name, state_slot);
+	}
+	else if (CFG_getStateFormat() == STATE_FORMAT_SRM
+	 	  || CFG_getStateFormat() == STATE_FORMAT_SRM_UNCOMRESSED) {
+		strcpy(work_name, game.name);
+		char* tmp = strrchr(work_name, '.');
+		if (tmp != NULL && strlen(tmp) > 2 && strlen(tmp) <= 5) {
+			tmp[0] = '\0';
+		}
+
+		if(state_slot == AUTO_RESUME_SLOT)
+			sprintf(filename, "%s/%s.state.auto", core.states_dir, work_name);
+		else 
+			sprintf(filename, "%s/%s.state%i", core.states_dir, work_name, state_slot);
 	}
 	else {
 		sprintf(filename, "%s/%s.st%i", core.states_dir, game.name, state_slot);
@@ -803,7 +816,7 @@ static void State_read(void) { // from picoarch
 
 	// TODO: rzipstream_open can also handle uncompressed, else branch is probably unnecessary
 	// srm, potentially compressed
-	if (CFG_getStateFormat() == STATE_FORMAT_SRM) {
+	if (CFG_getStateFormat() == STATE_FORMAT_SRM || (CFG_getStateFormat() == STATE_FORMAT_SRM_EXTRADOT) {
 		state_rzfile = rzipstream_open(filename, RETRO_VFS_FILE_ACCESS_READ);
 		if(!state_rzfile) {
 			if (state_slot!=8) { // st8 is a default state in MiniUI and may not exist, that's okay
@@ -899,7 +912,7 @@ static void State_write(void) { // from picoarch
 	char filename[MAX_PATH];
 	State_getPath(filename);
 #ifdef HAS_SRM
-	if (CFG_getStateFormat() == STATE_FORMAT_SRM) {
+	if (CFG_getStateFormat() == STATE_FORMAT_SRM || (CFG_getStateFormat() == STATE_FORMAT_SRM_EXTRADOT) {
 		if(!rzipstream_write_file(filename, state, state_size)) {
 			LOG_error("rzipstream: Error writing state data to file: %s\n", filename);
 			goto error;

--- a/workspace/all/settings/settings.cpp
+++ b/workspace/all/settings/settings.cpp
@@ -310,9 +310,9 @@ int main(int argc, char *argv[])
             { return CFG_getSaveFormat(); }, [](const std::any &value)
             { CFG_setSaveFormat(std::any_cast<int>(value)); },
             []() { CFG_setSaveFormat(CFG_DEFAULT_SAVEFORMAT);}},
-            new MenuItem{ListItemType::Generic, "Save state format", "The save state format to use.\nMinUI: Game.st0, Retroarch: Game.state.0", 
-            {(int)STATE_FORMAT_SAV, (int)STATE_FORMAT_SRM, (int)STATE_FORMAT_SRM_UNCOMRESSED}, 
-            {"MinUI (default)", "Retroarch (compressed)", "Retroarch (uncompressed)"}, []() -> std::any
+            new MenuItem{ListItemType::Generic, "Save state format", "The save state format to use. MinUI: Game.st0, \nRetroarch-ish: Game.state.0, Retroarch: Game.state0", 
+            {(int)STATE_FORMAT_SAV, (int)STATE_FORMAT_SRM_EXTRADOT, (int)STATE_FORMAT_SRM_UNCOMRESSED_EXTRADOT, (int)STATE_FORMAT_SRM, (int)STATE_FORMAT_SRM_UNCOMRESSED}, 
+            {"MinUI (default)", "Retroarch-ish (compressed)", "Retroarch-ish (uncompressed)", "Retroarch (compressed)", "Retroarch (uncompressed)"}, []() -> std::any
             { return CFG_getStateFormat(); }, [](const std::any &value)
             { CFG_setStateFormat(std::any_cast<int>(value)); },
             []() { CFG_setStateFormat(CFG_DEFAULT_STATEFORMAT);}},


### PR DESCRIPTION
This is for all the Syncthing people, this should've never been a thing. Selecting "Retroarch compressed/uncompressed" for STATE FORMAT will now yield the proper naming scheme without the extra dot. If you have been using the "wrong" Retroarch options until now, nothing will break unless you actively change your save format to the new option(s). The current options have been renamed accordingly:
- Retroarch (compressed) -> Retroarch-ish (compressed)
- Retroarch (uncompressed) -> Retroarch-ish (uncompressed)

Fixes #510 