### PR TITLE
fix: don't overwrite persisted displaycal settings on every boot

### DIFF
--- a/workspace/tg5040/libmsettings/msettings.c
+++ b/workspace/tg5040/libmsettings/msettings.c
@@ -328,7 +328,8 @@ static void applyDisplayCalDefaultsForDevice(Settings *target) {
 	target->displaycal_blue_gain = defaults.blue_gain;
 }
 
-void InitSettings(void) {	
+void InitSettings(void) {
+	int seed_displaycal = 0;
 	char* device = getenv("DEVICE");
 	is_brick = exactMatch("brick", device);
 	is_smartpro = exactMatch("smartpro", device);
@@ -359,6 +360,8 @@ void InitSettings(void) {
 				else {
 					// initialize with defaults
 					memcpy(settings, &DefaultSettings, shm_size);
+					// no displaycal fields before v11, seed device defaults
+					seed_displaycal = 1;
 
 					// overwrite with migrated data
 					if(version==10) {
@@ -519,11 +522,13 @@ void InitSettings(void) {
 			else {
 				// load defaults
 				memcpy(settings, &DefaultSettings, shm_size);
+				seed_displaycal = 1;
 			}
 		}
 		else {
 			// load defaults
 			memcpy(settings, &DefaultSettings, shm_size);
+			seed_displaycal = 1;
 		}
 		
 		// these shouldn't be persisted
@@ -540,7 +545,7 @@ void InitSettings(void) {
 		system("amixer sset 'DAC Swap' Off"); // Fix L/R channels
 	}
 
-	applyDisplayCalDefaultsForDevice(settings);
+	if (is_host && seed_displaycal) applyDisplayCalDefaultsForDevice(settings);
 
 	// This will implicitly update all other settings based on FN switch state
 	SetMute(settings->mute);


### PR DESCRIPTION
InitSettings() applied device displaycal defaults unconditionally, even for shm clients, so user-customized white point correction never survived a reboot on tg5040. Seed device defaults only in the host branch and only when the persisted file lacked displaycal fields (fresh defaults or pre-v11 migration), mirroring the h700 fix.

Closes #773 