### PR TITLE
build: add CONTAINER_MOUNT_OPTS to toolchain container runs

### DIFF
--- a/makefile.toolchain
+++ b/makefile.toolchain
@@ -18,12 +18,17 @@ ifeq (,$(CONTAINER_RUNTIME))
 $(error Neither docker nor podman found in PATH)
 endif
 
+# Extra flags injected before the workspace bind mount. On SELinux-enforcing
+# hosts (eg. Fedora Toolbox) set this to "--security-opt label=disable" so the
+# container can read the mounted workspace.
+CONTAINER_MOUNT_OPTS ?=
+
 RUNTIME_MARKER := $(HOST_WORKSPACE)/.container_runtime
 LAST_RUNTIME := $(shell cat $(RUNTIME_MARKER) 2>/dev/null)
 CURRENT_RUNTIME := $(notdir $(CONTAINER_RUNTIME))
 
 all: $(INIT_IF_NECESSARY)
-	$(CONTAINER_RUNTIME) run -it --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) $(IMAGE_NAME) /bin/bash
+	$(CONTAINER_RUNTIME) run -it --rm $(CONTAINER_MOUNT_OPTS) -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) $(IMAGE_NAME) /bin/bash
 
 $(INIT_IF_NECESSARY): $(GIT_IF_NECESSARY)
 	cd toolchains/$(PLATFORM)-toolchain && make .build
@@ -41,7 +46,7 @@ _runtime_check:
 		echo "Container runtime changed ($(LAST_RUNTIME) -> $(CURRENT_RUNTIME)), cleaning workspace build artifacts..."; \
 		PREV=$$(command -v $(LAST_RUNTIME) 2>/dev/null); \
 		if [ -n "$$PREV" ]; then \
-			$$PREV run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) $(IMAGE_NAME) /bin/bash -c \
+			$$PREV run --rm $(CONTAINER_MOUNT_OPTS) -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) $(IMAGE_NAME) /bin/bash -c \
 				'find $(GUEST_WORKSPACE) -depth -user root -delete 2>/dev/null; true'; \
 		else \
 			echo "Error: previous runtime $(LAST_RUNTIME) not available to clean root-owned artifacts."; \
@@ -51,16 +56,16 @@ _runtime_check:
 	fi
 
 build: $(INIT_IF_NECESSARY) _runtime_check
-	$(CONTAINER_RUNTIME) run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make'
+	$(CONTAINER_RUNTIME) run --rm $(CONTAINER_MOUNT_OPTS) -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make'
 	@echo "$(CURRENT_RUNTIME)" > $(RUNTIME_MARKER)
 
 build-cores: $(INIT_IF_NECESSARY) _runtime_check
-	$(CONTAINER_RUNTIME) run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make cores'
+	$(CONTAINER_RUNTIME) run --rm $(CONTAINER_MOUNT_OPTS) -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make cores'
 	@echo "$(CURRENT_RUNTIME)" > $(RUNTIME_MARKER)
 
 build-core: $(INIT_IF_NECESSARY) _runtime_check
 ifndef CORE
 	$(error CORE is not set)
 endif
-	$(CONTAINER_RUNTIME) run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) -e CORE=$(CORE) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make core'
+	$(CONTAINER_RUNTIME) run --rm $(CONTAINER_MOUNT_OPTS) -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) -e CORE=$(CORE) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make core'
 	@echo "$(CURRENT_RUNTIME)" > $(RUNTIME_MARKER)


### PR DESCRIPTION
Introduce an overridable CONTAINER_MOUNT_OPTS variable (default empty) and inject it before the workspace bind mount in every toolchain container invocation (all/build/build-cores/build-core and the runtime-check cleanup).

On SELinux-enforcing hosts (e.g. Fedora Toolbox) the toolchain container can't read the bind-mounted workspace, failing with "Permission denied" on the makefile. Setting CONTAINER_MOUNT_OPTS="--security-opt label=disable" lets the container access the mount without relabeling the tree (":z" relabeling doesn't work through rootless/flatpak-spawn setups).

Default-empty keeps existing behavior unchanged on non-SELinux hosts.