### PR TITLE
fix: doubled selection pill title when hardware indicator is shown

### DIFF
--- a/workspace/all/nextui/nextui.c
+++ b/workspace/all/nextui/nextui.c
@@ -3223,7 +3223,7 @@ int main (int argc, char *argv[]) {
 				SDL_LockMutex(animMutex);
 				if (list_show_entry_names) {
 					GFX_drawOnLayer(globalpill, pillRect.x, pillRect.y, globallpillW, globalpill->h, 1.0f, 0, LAYER_TRANSITION);
-					GFX_drawOnLayer(globalText, SCALE1(PADDING+BUTTON_PADDING), pilltargetTextY, globalText->w, globalText->h, 1.0f, 0, LAYER_SCROLLTEXT);
+					GFX_drawOnLayer(globalText, SCALE1(BUTTON_MARGIN + BUTTON_PADDING), pilltargetTextY, globalText->w, globalText->h, 1.0f, 0, LAYER_SCROLLTEXT);
 				}
 				SDL_UnlockMutex(animMutex);
 			}


### PR DESCRIPTION
## Summary

Fixes a bug where the **selected list item's title renders doubled / ghosted** whenever a hardware indicator (volume, brightness, or color temperature) is shown while sitting on a stationary selection.

## Root cause

The selected item's title is drawn twice, by design:

1. The list loop **bakes** the title into the screen at `x = SCALE1(BUTTON_MARGIN + BUTTON_PADDING)`.
2. The animated pill-text overlay (`globalText`) is drawn on top of it.

Two of the three `globalText` draw sites use that same x, so the overlay lands exactly on the baked copy and the label reads as a single crisp string.

The **static-redraw path** used `x = SCALE1(PADDING + BUTTON_PADDING)` instead. That path runs every frame while a volume/brightness/colortemp indicator is held on a stationary selection, so the overlay was drawn `SCALE1(PADDING - BUTTON_MARGIN)` = `SCALE1(5)` to the right of the baked title — producing the doubled/ghosted label.

## Fix

Align the static-redraw draw site with the other two (`nextui.c`), so the overlay always sits directly on top of the baked title:

```c
-GFX_drawOnLayer(globalText, SCALE1(PADDING+BUTTON_PADDING), pilltargetTextY, ...);
+GFX_drawOnLayer(globalText, SCALE1(BUTTON_MARGIN + BUTTON_PADDING), pilltargetTextY, ...);
```

One line, shared code — applies to all platforms.

## Testing

Built with the correct per-platform toolchains and verified on hardware:

| Device | Platform | Before | After |
|---|---|---|---|
| Trimui Smart Pro S | tg5050 | doubled text with indicator held | crisp ✓ |
| Trimui Brick | tg5040 | (not visibly doubled) | crisp, no regression ✓ |

Both boot normally and render the selected pill correctly during and after the indicator is shown.

### Note on tg5040 visibility

The doubling was only *visible* on tg5050, even though the code path is shared. On tg5040 the second (offset) copy stayed hidden because that platform composites the baked title differently — it presents through `/dev/fb0`, so the misaligned overlay copy was covered rather than shown. The fix is a no-op there visually (the overlay already coincides with the baked title after alignment) and was confirmed on hardware to introduce no regression or position shift.

### Before (TSP-S)
<img width="1280" height="720" alt="tsp-s_pill_doubling_BEFORE" src="https://github.com/user-attachments/assets/14a2b7f5-a2f6-4436-8ca6-5b7d14a38332" />

### After (TSP-S)
<img width="1280" height="720" alt="tsp-s_pill_doubling_AFTER" src="https://github.com/user-attachments/assets/3f3b6a8d-52f1-4689-b27f-dcbd99a5e8b4" />
