### PR TITLE
fix: correct supafaust PPU thread affinity for tg5050

### DIFF
--- a/skeleton/EXTRAS/Emus/tg5050/SUPA.pak/default.cfg
+++ b/skeleton/EXTRAS/Emus/tg5050/SUPA.pak/default.cfg
@@ -1,6 +1,6 @@
 -supafaust_pixel_format = rgb565
 -supafaust_thread_affinity_emu = 0x3
--supafaust_thread_affinity_ppu = 0xc
+-supafaust_thread_affinity_ppu = 0x10
 
 bind Up = UP
 bind Down = DOWN


### PR DESCRIPTION
SNES games crash immediately on launch on the Smart Pro S (tg5050). The emulator exits with `terminate called after throwing an instance of 'Mednafen::MDFN_Error'` before the game loop starts.

On tg5050 (sun55iw3 / Allwinner T527), only CPUs 0, 1, and 4 are online at game launch time:

```
/sys/devices/system/cpu/online: 0-1,4
```

The SUPA pak `default.cfg` was copied from the tg5040 config when tg5050 support was added (89158fe5), using the same affinity values tuned for tg5040's quad-core layout:

```
-supafaust_thread_affinity_emu = 0x3   # CPUs 0+1 — online on both platforms
-supafaust_thread_affinity_ppu = 0xc   # CPUs 2+3 — online on tg5040 , OFFLINE on tg5050
```

supafaust's `Thread_SetAffinity` calls `pthread_setaffinity_np` with the requested mask. When any CPU in the mask is offline, `EINVAL` is returned and the core throws `Mednafen::MDFN_Error` from inside `retro_load_game`, which propagates up and crashes the emulator before the game starts.

Changed the tg5050 PPU thread affinity to `0x10` (CPU 4), which is reliably online on tg5050:

```
-supafaust_thread_affinity_ppu = 0x10  # CPU 4 — online on tg5050
```

This preserves the same principle as tg5040 (emulation and PPU threads on separate CPUs) while using the correct CPU for the tg5050 topology.

Tested on physical Smart Pro S hardware. SNES games that previously crashed immediately now launch and run correctly.