### PR TITLE
Fix: font style setting follows the font intrinsic style

### DIFF
--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -95,6 +95,7 @@ static SDL_Rect asset_rects[ASSET_COUNT];
 static uint32_t asset_rgbs[ASSET_COLORS];
 static SDL_Rect input_rects[INPUT_COUNT];
 GFX_Fonts font;
+static int system_font_face_style = TTF_STYLE_NORMAL;
 
 ///////////////////////////////
 
@@ -324,6 +325,9 @@ int GFX_loadSystemFont(const char *fontPath)
 	font.tiny = TTF_OpenFont(fontPath, SCALE1(FONT_TINY));
 	font.micro = TTF_OpenFont(fontPath, SCALE1(FONT_MICRO));
 
+	// This value is only intrinsic before the configured style is applied.
+	system_font_face_style = font.large ? TTF_GetFontStyle(font.large) : TTF_STYLE_NORMAL;
+
 	TTF_SetFontStyle(font.large, CFG_getFontStyle());
 	TTF_SetFontStyle(font.medium, CFG_getFontStyle());
 	TTF_SetFontStyle(font.small, CFG_getFontStyle());
@@ -331,6 +335,11 @@ int GFX_loadSystemFont(const char *fontPath)
 	TTF_SetFontStyle(font.micro, CFG_getFontStyle());
 
 	return 0;
+}
+
+int GFX_getSystemFontFaceStyle(void)
+{
+	return system_font_face_style;
 }
 
 int GFX_updateColors(void)

--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -308,6 +308,9 @@ enum {
 };
 
 SDL_Surface* GFX_init(int mode);
+// Style reported by SDL_ttf immediately after opening the current font face,
+// before NextUI applies its configured synthetic style.
+int GFX_getSystemFontFaceStyle(void);
 #define GFX_resize PLAT_resizeVideo				// (int w, int h, int pitch);
 #define GFX_setSharpness PLAT_setSharpness // (int sharpness)
 #define GFX_setEffectColor PLAT_setEffectColor // (int color)

--- a/workspace/all/common/config.c
+++ b/workspace/all/common/config.c
@@ -1286,7 +1286,9 @@ int CFG_getFontStyle(void)
 
 void CFG_setFontStyle(int style)
 {
-    settings.fontStyle = clamp(style, 0x00, 0x01);
+    // SDL_ttf defines TTF_STYLE_NORMAL as 0x00 and TTF_STYLE_BOLD as 0x01.
+    // Use the values directly to keep config.c free of SDL dependencies.
+    settings.fontStyle = (style & 0x01) ? 0x01 : 0x00;
     CFG_sync();
     // reload the font to apply the new style (if the font supports it)
     CFG_setFontFile(CFG_getFontFile());

--- a/workspace/all/settings/settings.cpp
+++ b/workspace/all/settings/settings.cpp
@@ -421,14 +421,31 @@ int main(int argc, char *argv[])
             font_values.push_back(f.filename);
             font_labels.push_back(f.label);
         }
+
+        MenuItem *fontStyleItem = nullptr;
+        auto resetFontStyleToFaceDefault = [&fontStyleItem]() {
+            const int faceStyle = GFX_getSystemFontFaceStyle();
+            const int style = (faceStyle & TTF_STYLE_BOLD)
+                ? TTF_STYLE_BOLD
+                : TTF_STYLE_NORMAL;
+            CFG_setFontStyle(style);
+            if (fontStyleItem)
+                fontStyleItem->reselect();
+        };
+        auto selectFont = [&resetFontStyleToFaceDefault](const char *filename) {
+            CFG_setFontFile(filename);
+            resetFontStyleToFaceDefault();
+        };
+
         appearanceItems.push_back(new MenuItem{ListItemType::Generic, "Font", "The font to render all UI text.", font_values, font_labels,
             []() -> std::any { return std::string(CFG_getFontFile()); },
-            [](const std::any &value) { CFG_setFontFile(std::any_cast<std::string>(value).c_str()); },
-            []() { CFG_setFontFile(CFG_DEFAULT_FONT_FILE); }});
-        appearanceItems.push_back(new MenuItem{ListItemType::Generic, "Font style", "The style to render the UI font (e.g. bold)", std::vector<std::any>{0, 1}, std::vector<std::string>{"Normal", "Bold"},
+            [&selectFont](const std::any &value) { selectFont(std::any_cast<std::string>(value).c_str()); },
+            [&selectFont]() { selectFont(CFG_DEFAULT_FONT_FILE); }});
+        fontStyleItem = new MenuItem{ListItemType::Generic, "Font style", "The style to render the UI font (e.g. bold)", std::vector<std::any>{TTF_STYLE_NORMAL, TTF_STYLE_BOLD}, std::vector<std::string>{"Normal", "Bold"},
             []() -> std::any { return CFG_getFontStyle(); },
             [](const std::any &value) { CFG_setFontStyle(std::any_cast<int>(value)); },
-            []() { CFG_setFontStyle(CFG_DEFAULT_FONT_STYLE); }});
+            [&resetFontStyleToFaceDefault]() { resetFontStyleToFaceDefault(); }};
+        appearanceItems.push_back(fontStyleItem);
         appearanceItems.push_back(buildPaletteMenuItem());
         for (auto *item : colorMenuItems)
             appearanceItems.push_back(item);


### PR DESCRIPTION
## Description

The issue:
- NextUI setting "Font Style" is wrong on either bold or non-bold fonts.

TTF font bears a property what style it is - regular, bold, italic, bold italic. NextUI has a setting to choose the font style (Normal/Bold) which is applied to the system font.

The issue is that due to the the SDL_ttf implementation, there are several possibilities, two if which are wrong. Check the following table which demonstrates the issue on Rounded Mplus 1c font (default NextUI font):
| Font Face | Font style: Normal | Font style: Bold |
|--|--|--|
| Regular | <img width="300" alt="image" src="https://github.com/user-attachments/assets/6f3db54e-ee51-43ae-b752-0e101b526e88" /><br>font drawn Regular<br>Correct | <img width="300" alt="image" src="https://github.com/user-attachments/assets/b3b70ad9-1362-4192-9965-84b1050901c7" /><br>font drawn Bold (synthetic)<br>Inconsistent stroke width, digit metrics |
| Bold | <img width="300" alt="image" src="https://github.com/user-attachments/assets/3cda1f30-f61a-42e6-80db-505ed3d02f7a" /><br>font drawn Bold<br>Incorrect - normal expected | <img width="300" alt="image" src="https://github.com/user-attachments/assets/274810a9-bee8-44b5-9fc7-efcd59cd9169" /><br>font drawn Bold<br>Correct |

From the table it is clear that:
- Normal style setting yields the Bold look for a Bold face font
- Bold style setting produces an unbalanced look for a Regular face font.
- The only correct visual representation of the font is when the style setting matches the intrinsic font face.

Matching font style setting to the font is important even when system font is bold - third-party apps may use their own fonts but rely on the font style to match NextUI's look-and-fell.

https://github.com/LoveRetro/NextUI/pull/749 which added the font style setting made it sticky. As a result, when user selected a font with a different font face weight, they get either a non-optimal "synthetic bold" look or a wrong bold look on a normal setting.

This change implements a better approach: on font selection, font style resets to match the selected font face. This way on a font change it always produces the correct combination.

### Brief history of the default NextUI font

- 2025-02-01 - v0.01-beta - BPreplay Bold
- 2025-02-28 - v1.7.1-release - Rounded Mplus 1c Bold
- 2025-02-28 - v1.7.2-release - ChillRoundM Regular
- 2025-03-01 - v1.8.0-release - Rounded Mplus 1c Bold
- 2025-04-09 - v3.0.0-release - Rounded Mplus 1c Bold

There was no option to control the style of the font, it was dictated by the font file (same as Normal today).

- 2026-07-09 - v6.12.0 (PR #749) introduced a setting to control font style.

## Change

- add `GFX_getSystemFontFaceStyle()` to detect the intrinsic font style before NextUI applies the configured style
- reset the Font Style setting after each font selection and each Appearance reset
- map values in `CFG_setFontStyle()` to Normal or Bold from the SDL_ttf Bold bit

## Testing

- [x] check on tg5040, desktop
- [x] confirm that when I select a Regular face font, Font Style setting drops to Normal